### PR TITLE
47 account tab

### DIFF
--- a/components/UserCard.tsx
+++ b/components/UserCard.tsx
@@ -1,0 +1,32 @@
+import React from "react"
+import { Text, View } from "react-native"
+import { useStyles } from "../context/styles.context"
+import { Card } from "./Card"
+import { FontAwesome, FontAwesome5 } from "@expo/vector-icons"
+
+const UserCard = ({ user, role, phone, email }) => {
+  const { styles } = useStyles()
+
+  return (
+    <Card>
+      <Text style={styles.userCardRegisteredAs}>
+        Registered As:&nbsp;{role}
+      </Text>
+      <Text style={styles.userCardName}>{user}</Text>
+
+      <View style={styles.userCardDivider}></View>
+
+      <Text style={styles.userCardPhoneEmail}>
+        <FontAwesome5 name="phone-alt" size={11} color="#318AC7" />
+        &nbsp;&nbsp;{phone}
+      </Text>
+
+      <Text style={styles.userCardPhoneEmail}>
+        <FontAwesome name="envelope" size={11} color="#318AC7" />
+        &nbsp;&nbsp;{email}
+      </Text>
+    </Card>
+  )
+}
+
+export default UserCard

--- a/context/styles.context.tsx
+++ b/context/styles.context.tsx
@@ -409,8 +409,19 @@ export default function StylesProvider({ children }: { children: any }) {
     userCardDivider: {
       width: "100%",
       height: 1,
-      backgroundColor: "rgba(196, 196, 196, 0.5)",
+      backgroundColor: "#C4C4C4",
       marginBottom: 7,
+    },
+
+    // SIGN OUT
+    signOut: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      fontFamily: "ZillaSlab-Medium",
+      fontWeight: 700,
+      fontSize: 7.5,
+      color: "#808080",
     },
   }
   const styles = StyleSheet.create(initialState)

--- a/context/styles.context.tsx
+++ b/context/styles.context.tsx
@@ -387,9 +387,38 @@ export default function StylesProvider({ children }: { children: any }) {
       alignItems: "center",
       color: "#EF364B",
     },
+
+    // USER CARD
+    userCardName: {
+      fontFamily: "Fregata-Sans",
+      fontSize: 44,
+    },
+    userCardPhoneEmail: {
+      fontFamily: "ZillaSlab-Medium",
+      fontWeight: 600,
+      fontSize: 11,
+    },
+    userCardRegisteredAs: {
+      fontFamily: "ZillaSlab-Medium",
+      fontSize: "5px",
+      fontSyle: "normal",
+      fontWeight: 700,
+      color: "#EF364B",
+      marginBottom: "-16px",
+    },
+    userCardDivider: {
+      width: "100%",
+      height: 1,
+      backgroundColor: "rgba(196, 196, 196, 0.5)",
+      marginBottom: 7,
+    },
   }
   const styles = StyleSheet.create(initialState)
-  return <StylesContext.Provider value={{ styles }}>{children}</StylesContext.Provider>
+  return (
+    <StylesContext.Provider value={{ styles }}>
+      {children}
+    </StylesContext.Provider>
+  )
 }
 
 export const useStyles = () => {

--- a/screens/Account.tsx
+++ b/screens/Account.tsx
@@ -5,6 +5,7 @@ import logo from "../assets/images/c4k-logo.png"
 import { useStyles } from "../context/styles.context"
 import UserCard from "../components/UserCard"
 import { Entypo } from "@expo/vector-icons"
+import ScreenWrapper from "./ScreenWrapper"
 
 const hardCodedUser = {
   user: "Robbie Green",
@@ -18,30 +19,19 @@ export const Account = () => {
   const { signOut } = useUser()
 
   return (
-    <View style={styles.page}>
-      <View style={styles.sectionContainer}>
-        <Image
-          source={logo}
-          style={{
-            width: 180,
-            height: 180,
-            alignSelf: "center",
-            marginBottom: 100,
-          }}
-        />
-        <UserCard
-          user={hardCodedUser.user}
-          role={hardCodedUser.role}
-          phone={hardCodedUser.phone}
-          email={hardCodedUser.email}
-        />
-        <TouchableOpacity onPress={signOut}>
-          <View style={styles.signOut}>
-            Sign Out&nbsp;&nbsp;
-            <Entypo name="log-out" size={12} color="#808080" />
-          </View>
-        </TouchableOpacity>
-      </View>
-    </View>
+    <ScreenWrapper>
+      <UserCard
+        user={hardCodedUser.user}
+        role={hardCodedUser.role}
+        phone={hardCodedUser.phone}
+        email={hardCodedUser.email}
+      />
+      <TouchableOpacity onPress={signOut}>
+        <View style={styles.signOut}>
+          Sign Out&nbsp;&nbsp;
+          <Entypo name="log-out" size={12} color="#808080" />
+        </View>
+      </TouchableOpacity>
+    </ScreenWrapper>
   )
 }

--- a/screens/Account.tsx
+++ b/screens/Account.tsx
@@ -1,9 +1,10 @@
 import React from "react"
-import { View, Text, Pressable, Image } from "react-native"
+import { View, Text, Pressable, Image, TouchableOpacity } from "react-native"
 import { useUser } from "../context/user.context"
 import logo from "../assets/images/c4k-logo.png"
 import { useStyles } from "../context/styles.context"
 import UserCard from "../components/UserCard"
+import { Entypo } from "@expo/vector-icons"
 
 const hardCodedUser = {
   user: "Robbie Green",
@@ -34,11 +35,12 @@ export const Account = () => {
           phone={hardCodedUser.phone}
           email={hardCodedUser.email}
         />
-        <View style={styles.sectionContainer}>
-          <Pressable style={styles.button} onPress={signOut}>
-            <Text style={styles.buttonText}>{"SIGN OUT"}</Text>
-          </Pressable>
-        </View>
+        <TouchableOpacity onPress={signOut}>
+          <View style={styles.signOut}>
+            Sign Out&nbsp;&nbsp;
+            <Entypo name="log-out" size={12} color="#808080" />
+          </View>
+        </TouchableOpacity>
       </View>
     </View>
   )

--- a/screens/Account.tsx
+++ b/screens/Account.tsx
@@ -1,8 +1,16 @@
 import React from "react"
-import { View, StyleSheet, Text, Pressable, Image } from "react-native"
+import { View, Text, Pressable, Image } from "react-native"
 import { useUser } from "../context/user.context"
 import logo from "../assets/images/c4k-logo.png"
 import { useStyles } from "../context/styles.context"
+import UserCard from "../components/UserCard"
+
+const hardCodedUser = {
+  user: "Robbie Green",
+  role: "Chaperone",
+  phone: "(615) 601-5046",
+  email: "imrobbiegreen@gmail.com",
+}
 
 export const Account = () => {
   const { styles } = useStyles()
@@ -19,6 +27,12 @@ export const Account = () => {
             alignSelf: "center",
             marginBottom: 100,
           }}
+        />
+        <UserCard
+          user={hardCodedUser.user}
+          role={hardCodedUser.role}
+          phone={hardCodedUser.phone}
+          email={hardCodedUser.email}
         />
         <View style={styles.sectionContainer}>
           <Pressable style={styles.button} onPress={signOut}>


### PR DESCRIPTION
# Description
This PR implements #47.
- Added `UserCard` component that accepts `{ user, role, phone, email }` props
- Used hard coded data for `UserCard` component on Account Screen
- Added functional Sign out text and icon
- Wrapped `Account.tsx` Screen with `ScreenWrapper` to match the style on figma
# Demo
![demo](https://user-images.githubusercontent.com/10107412/141445625-5f9a1fb0-9499-4fcf-b021-784c117d1222.gif)
# Possible Issue
![diff](https://user-images.githubusercontent.com/10107412/141445963-ea188eda-47be-48b4-9272-f5c2535fb0cf.png)

I used `Fregata-Sans` font for the name on the `UserCard` but it looks different than the one on Figma.

